### PR TITLE
removed port 82 from qa environment

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,7 +59,6 @@ func New(cfg *Config) (*Client, error) {
 	if cfg.Location != "" {
 		location = cfg.Location + "-api"
 		if cfg.Location == "qa" {
-			port = ":82"
 			secure = ""
 		}
 		if cfg.Location == "localhost" {


### PR DESCRIPTION
## Summary:
removed port 82 from qa environment

## PR - Merge Checklist:
-- Verify:
- [x] ALL tests have passed

## Risks:
None, change only affects Stream staff running qa tests

## Rollback:
git revert