### PR TITLE
Added JWT token builder for updating activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples/
 .idea
 stream-go.iml
 test.sh
+projectFilesBackup


### PR DESCRIPTION
Code needs to send JWT for updating activities, per https://github.com/GetStream/stream-go/issues/8

Since we don't know how many feeds we're updating activities for by the time we need to build the token, we are going to wildcard the feed id in the token generator.