### PR TITLE
V1.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
  Change history
 ================
 
+1.0.0
+=====
+* breaking changes:
+  * actors, objects and targets no longer need to be FeedID values, just strings
+
 0.9.2
 =====
 * fixed a permission issue with updated activities, and have changed the auth mechanism for them from

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 =====
 * breaking changes:
   * actors, objects and targets no longer need to be FeedID values, just strings
+* non-breaking changes:
+  * foreign id no longer has to be a UUID, it can be a string as well
 
 0.9.2
 =====

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ Dev Branch: [![Build Status](https://travis-ci.org/GetStream/stream-go.svg?branc
 
 Beta client library for [GetStream.io](//getstream.io).
 
-This library could not exist without the efforts of several open-source community members, 
-including the awesome folks at [MrHenry](//github.com/mrhenry) and 
+This library could not exist without the efforts of several open-source community members,
+including the awesome folks at [MrHenry](//github.com/mrhenry) and
 [HyperWorks](//github.com/hyperworks). Thank you so much for contributing
 to our community!
 
-The code provided by the MrHenry team is used with written permission; we are working 
-with them to get a final license in place. Stream will be modifying the codebase 
-together with MrHenry over time, so we especially want to point out how great they 
+The code provided by the MrHenry team is used with written permission; we are working
+with them to get a final license in place. Stream will be modifying the codebase
+together with MrHenry over time, so we especially want to point out how great they
 have been working with us to release this library.
 
 ### Beta
 
-We are releasing this as our v0.9.0 beta since there may be bugs, and inevitable cleanup 
+We are releasing this as our v0.9.0 beta since there may be bugs, and inevitable cleanup
 will happen along the way. Please do not hesitate to [contact us](mailto:support@getstream.io)
-if you see something strange happening. We'd be happy to consider any and all pull 
+if you see something strange happening. We'd be happy to consider any and all pull
 requests from the community as well!
 
 ### Roadmap
@@ -68,7 +68,7 @@ Location string = "us-east"
 // TimeoutInt is an optional integer parameter to define
 // the number of seconds before your connection will hang-up
 // during a request; you can set this to any non-negative
-// and non-zero whole number, and will default to 3 
+// and non-zero whole number, and will default to 3
 TimeoutInt: 3
 
 client, err := getstream.New(&getstream.Config{
@@ -111,8 +111,8 @@ import "github.com/pborman/uuid"
 activity, err := bobFeed.AddActivity(&Activity{
     Verb:      "post",
     ForeignID: uuid.New(),
-    Object:    FeedID("flat:eric"),
-    Actor:     FeedID("flat:john"),
+    Object:    "flat:eric",
+    Actor:     "flat:john",
 })
 if err != nil {
     return err
@@ -139,8 +139,8 @@ if err != nil {
 
 // create a JWT token for the feed
 token, err := client.Signer.GenerateFeedScopeToken(
-    getstream.ScopeContextFeed, 
-    getstream.ScopeActionRead, 
+    getstream.ScopeContextFeed,
+    getstream.ScopeActionRead,
     bobFeed)
 if err != nil {
     fmt.Println(err)
@@ -160,7 +160,7 @@ if err != nil {
 }
 ```
 
-JWT support is not yet fully tested on the library, but we'd love to 
+JWT support is not yet fully tested on the library, but we'd love to
 hear any feedback you have as you try it out.
 
 ### API Support
@@ -205,7 +205,7 @@ Payload building Follows our API standards for all request payloads
 - `data` : Statically typed payloads as `json.RawMessage`
 - `metadata` : Top-level key/value pairs
 
-You can/should use `data` to send Go structures through the library. This 
+You can/should use `data` to send Go structures through the library. This
 will give you the benefit of Go's static type system. If you are unable
 to determine a type (or compatible type) for the contents of an Activity,
 you can use `metadata` which is a `map[string]string`; encoding this to
@@ -213,7 +213,7 @@ JSON will move these values to the top-level, so any keys you define in
 your `metadata` which conflict with our standard top-level keys will be
 overwritten.
 
-The benefit of this `metadata` structure is that these key/value pairs 
+The benefit of this `metadata` structure is that these key/value pairs
 will be exposed to Stream's internals such as ranking.
 
 ### Design Choices
@@ -224,9 +224,9 @@ package. This choice meant exposing some attributes that perhaps should
 be left private, and we expect this re-refactoring will take place over
 time.
 
-The MrHenry team noted this about the Flat / Aggregated / Notification 
+The MrHenry team noted this about the Flat / Aggregated / Notification
 Feed types:
-- they have separate structures and methods to prevent the impact of 
+- they have separate structures and methods to prevent the impact of
 future Stream changes
 - if two types of feeds grow farther apart, incorporated future changes
 in this client should not breaking everything
@@ -238,11 +238,11 @@ Have we mentioned the team at [MrHenry](//github.com/mrhenry) yet??
 ##### Credits from MrHenry that we wanted to pass along as well:
 
 This pkg started out as a fork from [HyperWorks](//github.com/hyperworks/go-getstream)
-and still borrows snippets (token & errors) from the original. We 
-decided to make this a separate repo entirely because drastic changes 
+and still borrows snippets (token & errors) from the original. We
+decided to make this a separate repo entirely because drastic changes
 were made to the interface and internal workings.
 
 We received great support from Stream while creating this pkg for which
-we are very grateful, and we also want to thank them for creating 
+we are very grateful, and we also want to thank them for creating
 Stream in the first place.
 

--- a/activity.go
+++ b/activity.go
@@ -2,7 +2,6 @@ package getstream
 
 import (
 	"encoding/json"
-	"errors"
 	"regexp"
 	"strings"
 	"time"
@@ -13,10 +12,10 @@ import (
 // It is also the response from Fetch and List Requests
 type Activity struct {
 	ID        string
-	Actor     FeedID
+	Actor     string
 	Verb      string
-	Object    FeedID
-	Target    FeedID
+	Object    string
+	Target    string
 	Origin    FeedID
 	TimeStamp *time.Time
 
@@ -37,16 +36,16 @@ func (a Activity) MarshalJSON() ([]byte, error) {
 		payload[key] = value
 	}
 
-	payload["actor"] = a.Actor.Value()
+	payload["actor"] = a.Actor
 	payload["verb"] = a.Verb
-	payload["object"] = a.Object.Value()
+	payload["object"] = a.Object
 	payload["origin"] = a.Origin.Value()
 
 	if a.ID != "" {
 		payload["id"] = a.ID
 	}
 	if a.Target != "" {
-		payload["target"] = a.Target.Value()
+		payload["target"] = a.Target
 	}
 
 	if a.Data != nil {
@@ -54,13 +53,6 @@ func (a Activity) MarshalJSON() ([]byte, error) {
 	}
 
 	if a.ForeignID != "" {
-		r, err := regexp.Compile("^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$")
-		if err != nil {
-			return nil, err
-		}
-		if !r.MatchString(a.ForeignID) {
-			return nil, errors.New("invalid ForeignID")
-		}
 		payload["foreign_id"] = a.ForeignID
 	}
 
@@ -113,7 +105,7 @@ func (a *Activity) UnmarshalJSON(b []byte) (err error) {
 		} else if lowerKey == "actor" {
 			var strValue string
 			json.Unmarshal(*value, &strValue)
-			a.Actor = FeedID(strValue)
+			a.Actor = strValue
 		} else if lowerKey == "verb" {
 			var strValue string
 			json.Unmarshal(*value, &strValue)
@@ -125,7 +117,7 @@ func (a *Activity) UnmarshalJSON(b []byte) (err error) {
 		} else if lowerKey == "object" {
 			var strValue string
 			json.Unmarshal(*value, &strValue)
-			a.Object = FeedID(strValue)
+			a.Object = strValue
 		} else if lowerKey == "origin" {
 			var strValue string
 			json.Unmarshal(*value, &strValue)
@@ -133,7 +125,7 @@ func (a *Activity) UnmarshalJSON(b []byte) (err error) {
 		} else if lowerKey == "target" {
 			var strValue string
 			json.Unmarshal(*value, &strValue)
-			a.Target = FeedID(strValue)
+			a.Target = strValue
 		} else if lowerKey == "time" {
 			var strValue string
 			err := json.Unmarshal(*value, &strValue)

--- a/activity_test.go
+++ b/activity_test.go
@@ -12,8 +12,8 @@ func TestActivityMarshallJson(t *testing.T) {
 	activity := &getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	}
 
 	_, err := activity.MarshalJSON()
@@ -26,15 +26,12 @@ func TestActivityBadForeignKeyMarshall(t *testing.T) {
 	activity := &getstream.Activity{
 		Verb:      "post",
 		ForeignID: "not a real foreign id",
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	}
 
 	_, err := activity.MarshalJSON()
-	if err == nil {
-		t.Fatal(err)
-	}
-	if err.Error() != "invalid ForeignID" {
+	if err != nil && err.Error() != "invalid ForeignID" {
 		t.Fatal(errors.New("Expected activity.MarshalJSON() to fail on non-UUID ForeignID, it failed because of this:" + err.Error()))
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -435,8 +435,8 @@ func TestAddActivityToMany(t *testing.T) {
 	activity := &getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	}
 
 	err = client.AddActivityToMany(*activity, feeds)

--- a/feed_aggregated_test.go
+++ b/feed_aggregated_test.go
@@ -23,8 +23,8 @@ func TestExampleAggregatedFeed_AddActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -47,8 +47,8 @@ func TestAggregatedFeedAddActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -83,8 +83,8 @@ func TestAggregatedFeedAddActivityWithTo(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 		To:        []getstream.Feed{toFeed},
 	})
 	if err != nil {
@@ -114,8 +114,8 @@ func TestAggregatedFeedRemoveActivity(t *testing.T) {
 
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:   "post",
-		Object: getstream.FeedID("flat:eric"),
-		Actor:  getstream.FeedID("flat:john"),
+		Object: "flat:eric",
+		Actor:  "flat:john",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -149,8 +149,8 @@ func TestAggregatedFeedRemoveByForeignIDActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -187,8 +187,8 @@ func TestAggregatedFeedActivities(t *testing.T) {
 	_, err = feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Error(err)
@@ -222,13 +222,13 @@ func TestAggregatedFeedAddActivities(t *testing.T) {
 		{
 			Verb:      "post",
 			ForeignID: uuid.New(),
-			Object:    getstream.FeedID("flat:eric"),
-			Actor:     getstream.FeedID("flat:john"),
+			Object:    "flat:eric",
+			Actor:     "flat:john",
 		}, {
 			Verb:      "walk",
 			ForeignID: uuid.New(),
-			Object:    getstream.FeedID("flat:john"),
-			Actor:     getstream.FeedID("flat:eric"),
+			Object:    "flat:john",
+			Actor:     "flat:eric",
 		},
 	})
 	if err != nil {
@@ -376,10 +376,10 @@ func TestAggregatedActivityMetaData(t *testing.T) {
 
 	activity := getstream.Activity{
 		ForeignID: uuid.New(),
-		Actor:     getstream.FeedID("user:eric"),
-		Object:    getstream.FeedID("user:bob"),
-		Target:    getstream.FeedID("user:john"),
-		Origin:    getstream.FeedID("user:barry"),
+		Actor:     "user:eric",
+		Object:    "user:bob",
+		Target:    "user:john",
+		Origin:    "user:barry",
 		Verb:      "post",
 		TimeStamp: &now,
 		Data:      &raw,

--- a/feed_flat_test.go
+++ b/feed_flat_test.go
@@ -24,41 +24,14 @@ func TestExampleFlatFeedAddActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	_ = activity
-}
-
-func TestFlatFeedAddActivityFail(t *testing.T) {
-	client, err := PreTestSetup()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	feed, err := client.FlatFeed("flat", "bob")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = feed.AddActivity(&getstream.Activity{
-		Verb:      "post",
-		ForeignID: "not a real foreign id",
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
-	})
-	if err == nil {
-		t.Fatal(err)
-	}
-
-	_, err = client.FlatFeed("flat&skinny", "bob@#awesome")
-	if err == nil {
-		t.Fatal(err)
-	}
 }
 
 func TestFlatFeedAddActivity(t *testing.T) {
@@ -75,8 +48,8 @@ func TestFlatFeedAddActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -116,8 +89,8 @@ func TestFlatFeedAddActivityWithTo(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 		To:        []getstream.Feed{feedTo, feedToB},
 	})
 	if err != nil {
@@ -151,8 +124,8 @@ func TestFlatFeedUUID(t *testing.T) {
 		activity, err := feed.AddActivity(&getstream.Activity{
 			Verb:      "post",
 			ForeignID: uuid.New(),
-			Object:    getstream.FeedID("flat:eric"),
-			Actor:     getstream.FeedID("flat:john"),
+			Object:    "flat:eric",
+			Actor:     "flat:john",
 		})
 		if err != nil {
 			t.Log("fail add activity with UUID :", err)
@@ -183,8 +156,8 @@ func TestFlatFeedRemoveActivity(t *testing.T) {
 
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:   "post",
-		Object: getstream.FeedID("flat:eric"),
-		Actor:  getstream.FeedID("flat:john"),
+		Object: "flat:eric",
+		Actor:  "flat:john",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -218,8 +191,8 @@ func TestFlatFeedRemoveByForeignIDActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Error(err)
@@ -256,8 +229,8 @@ func TestFlatFeedGetActivities(t *testing.T) {
 	_, err = feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Error(err)
@@ -268,7 +241,7 @@ func TestFlatFeedGetActivities(t *testing.T) {
 		t.Error(err)
 	}
 
-	if activities.Activities[0].Actor != getstream.FeedID("flat:john") {
+	if activities.Activities[0].Actor != "flat:john" {
 		t.Error("Activity read from stream did not match")
 	}
 
@@ -293,13 +266,13 @@ func TestFlatFeedAddActivities(t *testing.T) {
 		{
 			Verb:      "post",
 			ForeignID: uuid.New(),
-			Object:    getstream.FeedID("flat:eric"),
-			Actor:     getstream.FeedID("flat:john"),
+			Object:    "flat:eric",
+			Actor:     "flat:john",
 		}, {
 			Verb:      "walk",
 			ForeignID: uuid.New(),
-			Object:    getstream.FeedID("flat:john"),
-			Actor:     getstream.FeedID("flat:eric"),
+			Object:    "flat:john",
+			Actor:     "flat:eric",
 		},
 	})
 	if err != nil {
@@ -476,9 +449,9 @@ func TestFlatActivityMetaData(t *testing.T) {
 
 	activity := getstream.Activity{
 		ForeignID: uuid.New(),
-		Actor:     getstream.FeedID("user:eric"),
-		Object:    getstream.FeedID("user:bob"),
-		Target:    getstream.FeedID("user:john"),
+		Actor:     "user:eric",
+		Object:    "user:bob",
+		Target:    "user:john",
 		Verb:      "post",
 		TimeStamp: &now,
 		Data:      &raw,
@@ -622,8 +595,8 @@ func TestFlatFeedUpdateActivities(t *testing.T) {
 	activity1 := &getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:1"),
-		Actor:     getstream.FeedID("flat:2"),
+		Object:    "flat:1",
+		Actor:     "flat:2",
 	}
 	activity1, err = bobFeed.AddActivity(activity1)
 	if err != nil {
@@ -633,16 +606,16 @@ func TestFlatFeedUpdateActivities(t *testing.T) {
 	activity2 := &getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:1"),
-		Actor:     getstream.FeedID("flat:2"),
+		Object:    "flat:1",
+		Actor:     "flat:2",
 	}
 	activity2, err = bobFeed.AddActivity(activity2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	activity1.Actor = getstream.FeedID("flat:123")
-	activity2.Actor = getstream.FeedID("flat:123")
+	activity1.Actor = "flat:123"
+	activity2.Actor = "flat:123"
 
 	// push those activities to Stream
 	// unlike the AddActivities method, the UpdateActivities call only returns an error value

--- a/feed_notification_test.go
+++ b/feed_notification_test.go
@@ -23,8 +23,8 @@ func TestExampleNotificationFeed_AddActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -47,8 +47,8 @@ func TestNotificationFeedAddActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Error(err)
@@ -83,8 +83,8 @@ func TestNotificationFeedAddActivityWithTo(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 		To:        []getstream.Feed{feedTo},
 	})
 	if err != nil {
@@ -114,8 +114,8 @@ func TestNotificationFeedRemoveActivity(t *testing.T) {
 
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:   "post",
-		Object: getstream.FeedID("flat:eric"),
-		Actor:  getstream.FeedID("flat:john"),
+		Object: "flat:eric",
+		Actor:  "flat:john",
 	})
 	if err != nil {
 		t.Error(err)
@@ -149,8 +149,8 @@ func TestNotificationFeedRemoveByForeignIDActivity(t *testing.T) {
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Error(err)
@@ -187,8 +187,8 @@ func TestNotificationFeedActivities(t *testing.T) {
 	_, err = feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
 		ForeignID: uuid.New(),
-		Object:    getstream.FeedID("flat:eric"),
-		Actor:     getstream.FeedID("flat:john"),
+		Object:    "flat:eric",
+		Actor:     "flat:john",
 	})
 	if err != nil {
 		t.Error(err)
@@ -222,13 +222,13 @@ func TestNotificationFeedAddActivities(t *testing.T) {
 		&getstream.Activity{
 			Verb:      "post",
 			ForeignID: uuid.New(),
-			Object:    getstream.FeedID("flat:eric"),
-			Actor:     getstream.FeedID("flat:john"),
+			Object:    "flat:eric",
+			Actor:     "flat:john",
 		}, &getstream.Activity{
 			Verb:      "walk",
 			ForeignID: uuid.New(),
-			Object:    getstream.FeedID("flat:john"),
-			Actor:     getstream.FeedID("flat:eric"),
+			Object:    "flat:john",
+			Actor:     "flat:eric",
 		},
 	})
 	if err != nil {
@@ -351,8 +351,8 @@ func TestMarkAsSeen(t *testing.T) {
 
 	feed.AddActivities([]*getstream.Activity{
 		&getstream.Activity{
-			Actor:  getstream.FeedID("flat:larry"),
-			Object: getstream.FeedID("notification:larry"),
+			Actor:  "flat:larry",
+			Object: "notification:larry",
 			Verb:   "post",
 		},
 	})
@@ -394,8 +394,8 @@ func TestMarkAsRead(t *testing.T) {
 
 	feed.AddActivities([]*getstream.Activity{
 		&getstream.Activity{
-			Actor:  getstream.FeedID("flat:larry"),
-			Object: getstream.FeedID("notification:larry"),
+			Actor:  "flat:larry",
+			Object: "notification:larry",
 			Verb:   "post",
 		},
 	})
@@ -450,10 +450,10 @@ func TestNotificationActivityMetaData(t *testing.T) {
 
 	activity := getstream.Activity{
 		ForeignID: uuid.New(),
-		Actor:     getstream.FeedID("user:eric"),
-		Object:    getstream.FeedID("user:bob"),
-		Target:    getstream.FeedID("user:john"),
-		Origin:    getstream.FeedID("user:barry"),
+		Actor:     "user:eric",
+		Object:    "user:bob",
+		Target:    "user:john",
+		Origin:    "user:barry",
 		Verb:      "post",
 		TimeStamp: &now,
 		Data:      &raw,


### PR DESCRIPTION
Please see CHANGELOG for breaking changes (actors, objects, targets no longer need to be FeedID types, they're just strings now, to follow convention with all of our other SDKs)