### PR TITLE
Allowing dashes in user id validations

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -3,18 +3,12 @@ package getstream
 import (
 	"errors"
 	"regexp"
-	"strings"
 )
 
+var validWord = regexp.MustCompile(`^[\w|-]+$`)
+
 func ValidateFeedSlug(feedSlug string) (string, error) {
-	r, err := regexp.Compile(`^\w+$`)
-	if err != nil {
-		return "", err
-	}
-
-	feedSlug = strings.Replace(feedSlug, "-", "_", -1)
-
-	if !r.MatchString(feedSlug) {
+	if !validWord.MatchString(feedSlug) {
 		return "", errors.New("invalid feedSlug")
 	}
 
@@ -22,14 +16,7 @@ func ValidateFeedSlug(feedSlug string) (string, error) {
 }
 
 func ValidateFeedID(feedID string) (string, error) {
-	r, err := regexp.Compile(`^\w+$`)
-	if err != nil {
-		return "", err
-	}
-
-	feedID = strings.Replace(feedID, "-", "_", -1)
-
-	if !r.MatchString(feedID) {
+	if !validWord.MatchString(feedID) {
 		return "", errors.New("invalid feedID")
 	}
 
@@ -37,14 +24,7 @@ func ValidateFeedID(feedID string) (string, error) {
 }
 
 func ValidateUserID(userID string) (string, error) {
-	r, err := regexp.Compile(`^\w+$`)
-	if err != nil {
-		return "", err
-	}
-
-	userID = strings.Replace(userID, "-", "_", -1)
-
-	if !r.MatchString(userID) {
+	if !validWord.MatchString(userID) {
 		return "", errors.New("invalid userID")
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -5,10 +5,10 @@ import (
 	"regexp"
 )
 
-var validWord = regexp.MustCompile(`^[\w|-]+$`)
-
 func ValidateFeedSlug(feedSlug string) (string, error) {
-	if !validWord.MatchString(feedSlug) {
+	validFeedSlug := regexp.MustCompile(`^\w+$`)
+
+	if !validFeedSlug.MatchString(feedSlug) {
 		return "", errors.New("invalid feedSlug")
 	}
 
@@ -16,7 +16,9 @@ func ValidateFeedSlug(feedSlug string) (string, error) {
 }
 
 func ValidateFeedID(feedID string) (string, error) {
-	if !validWord.MatchString(feedID) {
+	validFeedID := regexp.MustCompile(`^\w+$`)
+
+	if !validFeedID.MatchString(feedID) {
 		return "", errors.New("invalid feedID")
 	}
 
@@ -24,7 +26,9 @@ func ValidateFeedID(feedID string) (string, error) {
 }
 
 func ValidateUserID(userID string) (string, error) {
-	if !validWord.MatchString(userID) {
+	validUserID := regexp.MustCompile(`^[\w-]+$`)
+
+	if !validUserID.MatchString(userID) {
 		return "", errors.New("invalid userID")
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -25,14 +25,14 @@ func TestFeedSlug(t *testing.T) {
 		},
 		{
 			"Slug with word chars and dashes",
-			"f-o-o",
+			"f_o_o",
 
-			"f-o-o",
+			"f_o_o",
 			"",
 		},
 		{
 			"Slug with invalid chars",
-			"foo@",
+			"f-o-o",
 
 			"",
 			"invalid feedSlug",
@@ -70,14 +70,14 @@ func TestFeedID(t *testing.T) {
 		},
 		{
 			"Feed ID word chars and dashes",
-			"1-2-3",
+			"1_2_3",
 
-			"1-2-3",
+			"1_2_3",
 			"",
 		},
 		{
 			"Feed ID with invalid chars",
-			"123@",
+			"1-2-3",
 
 			"",
 			"invalid feedID",

--- a/utils_test.go
+++ b/utils_test.go
@@ -7,55 +7,136 @@ import (
 )
 
 func TestFeedSlug(t *testing.T) {
-	feedSlug, err := getstream.ValidateFeedSlug("foo")
-	if err != nil {
-		t.Error(err)
-	}
-	if feedSlug != "foo" {
-		t.Error("feedSlug not 'foo'")
+	var tests = []struct {
+		//given
+		description string
+		slug        string
+
+		//expected
+		validatedSlug string
+		errorMsg      string
+	}{
+		{
+			"Slug with word chars",
+			"foo",
+
+			"foo",
+			"",
+		},
+		{
+			"Slug with word chars and dashes",
+			"f-o-o",
+
+			"f-o-o",
+			"",
+		},
+		{
+			"Slug with invalid chars",
+			"foo@",
+
+			"",
+			"invalid feedSlug",
+		},
 	}
 
-	feedSlug, err = getstream.ValidateFeedSlug("f-o-o")
-	if err != nil {
-		t.Error(err)
-	}
-	if feedSlug != "f_o_o" {
-		t.Error("feedSlug not 'f_o_o'")
+	for _, test := range tests {
+		feedSlug, err := getstream.ValidateFeedSlug(test.slug)
+		if feedSlug != test.validatedSlug {
+			t.Errorf("Expected slug %v, got %v", test.validatedSlug, feedSlug)
+		}
+
+		if err != nil && err.Error() != test.errorMsg {
+			t.Errorf("Error %v does not match expected %v", test.errorMsg, err.Error())
+		}
 	}
 }
 
 func TestFeedID(t *testing.T) {
-	feedID, err := getstream.ValidateFeedID("123")
-	if err != nil {
-		t.Error(err)
-	}
-	if feedID != "123" {
-		t.Error("feedID not '123'")
+	var tests = []struct {
+		//given
+		description string
+		feedID      string
+
+		//expected
+		validatedFeedID string
+		errorMsg        string
+	}{
+		{
+			"Feed ID with word chars",
+			"123",
+
+			"123",
+			"",
+		},
+		{
+			"Feed ID word chars and dashes",
+			"1-2-3",
+
+			"1-2-3",
+			"",
+		},
+		{
+			"Feed ID with invalid chars",
+			"123@",
+
+			"",
+			"invalid feedID",
+		},
 	}
 
-	feedID, err = getstream.ValidateFeedID("1-2-3")
-	if err != nil {
-		t.Error(err)
-	}
-	if feedID != "1_2_3" {
-		t.Error("feedID not '1_2_3'")
+	for _, test := range tests {
+		feedID, err := getstream.ValidateFeedID(test.feedID)
+		if feedID != test.validatedFeedID {
+			t.Errorf("Expected feedID %v, got %v", test.validatedFeedID, feedID)
+		}
+
+		if err != nil && err.Error() != test.errorMsg {
+			t.Errorf("Error %v does not match expected %v", test.errorMsg, err.Error())
+		}
 	}
 }
 
 func TestUserID(t *testing.T) {
-	userID, err := getstream.ValidateUserID("123")
-	if err != nil {
-		t.Error(err)
-	}
-	if userID != "123" {
-		t.Error("userID not '123'")
+	var tests = []struct {
+		//given
+		description string
+		userID      string
+
+		//expected
+		validatedUserID string
+		errorMsg        string
+	}{
+		{
+			"User ID with word chars",
+			"123",
+
+			"123",
+			"",
+		},
+		{
+			"User ID word chars and dashes",
+			"1-2-3",
+
+			"1-2-3",
+			"",
+		},
+		{
+			"User ID with invalid chars",
+			"123@",
+
+			"",
+			"invalid userID",
+		},
 	}
 
-	userID, err = getstream.ValidateUserID("1-2-3")
-	if err != nil {
-		t.Error(err)
-	}
-	if userID != "1_2_3" {
-		t.Error("userSlug not '1_2_3'")
+	for _, test := range tests {
+		userID, err := getstream.ValidateUserID(test.userID)
+		if userID != test.validatedUserID {
+			t.Errorf("Expected userID %v, got %v", test.validatedUserID, userID)
+		}
+
+		if err != nil && err.Error() != test.errorMsg {
+			t.Errorf("Error %v does not match expected %v", test.errorMsg, err.Error())
+		}
 	}
 }


### PR DESCRIPTION
The current implementation of the validation checks are converting the
dashes to underscores, I assume this is to enable easier checking with
the regexp. This is however causing issues when the user ID is a UUID.
This commit allows the dashes to be considered valid, and moves the
regexp into a global var, as it currently uses the same validation.