### PR TITLE
Add update activities endpoint management

### DIFF
--- a/activity.go
+++ b/activity.go
@@ -2,7 +2,6 @@ package getstream
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 )
@@ -30,16 +29,6 @@ type Activity struct {
 
 type UpdateActivitiesRequest struct {
 	Activities []*Activity `json:"activities"`
-}
-
-func (a Activity) checkUpdatability() error {
-	if a.ForeignID == "" {
-		return fmt.Errorf("foreignID is required for updating activity")
-	}
-	if a.TimeStamp == nil || a.TimeStamp.IsZero() {
-		return fmt.Errorf("an activity must have a time in order to be updated")
-	}
-	return nil
 }
 
 // MarshalJSON is the custom marshal function for Activities

--- a/activity.go
+++ b/activity.go
@@ -2,6 +2,7 @@ package getstream
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -25,6 +26,20 @@ type Activity struct {
 
 	To       []FeedID
 	signedTo []string
+}
+
+type UpdateActivitiesRequest struct {
+	Activities []*Activity `json:"activities"`
+}
+
+func (a Activity) checkUpdatability() error {
+	if a.ForeignID == "" {
+		return fmt.Errorf("foreignID is required for updating activity")
+	}
+	if a.TimeStamp == nil || a.TimeStamp.IsZero() {
+		return fmt.Errorf("an activity must have a time in order to be updated")
+	}
+	return nil
 }
 
 // MarshalJSON is the custom marshal function for Activities

--- a/auth.go
+++ b/auth.go
@@ -49,5 +49,9 @@ func (a feedAuthenticator) Authenticate(signer *Signer, request *http.Request, c
 	if !ok {
 		return fmt.Errorf("missing action")
 	}
-	return signer.SignJWT(request, context, action, feed.FeedIDWithoutColon())
+	var feedID string
+	if feed != nil {
+		feedID = feed.FeedIDWithoutColon()
+	}
+	return signer.SignJWT(request, context, action, feedID)
 }

--- a/feed.go
+++ b/feed.go
@@ -185,11 +185,6 @@ func (f *baseFeed) RemoveActivityByForeignID(foreignId string) error {
 }
 
 func (f *baseFeed) UpdateActivities(activities ...*Activity) error {
-	for _, a := range activities {
-		if err := a.checkUpdatability(); err != nil {
-			return err
-		}
-	}
 	payload, err := json.Marshal(UpdateActivitiesRequest{Activities: activities})
 	if err != nil {
 		return fmt.Errorf("cannot marshal payload: %s", err)

--- a/feed.go
+++ b/feed.go
@@ -194,7 +194,9 @@ func (f *baseFeed) UpdateActivities(activities ...*Activity) error {
 	if err != nil {
 		return fmt.Errorf("cannot marshal payload: %s", err)
 	}
-	_, err = f.Client.post(nil, "activities/", payload, nil)
+
+	endpoint := "activities/"
+	_, err = f.Client.post(nil, endpoint, payload, nil)
 	if err != nil {
 		return fmt.Errorf("cannot update activities: %s", err)
 	}

--- a/feed.go
+++ b/feed.go
@@ -184,6 +184,23 @@ func (f *baseFeed) RemoveActivityByForeignID(foreignId string) error {
 	})
 }
 
+func (f *baseFeed) UpdateActivities(activities ...*Activity) error {
+	for _, a := range activities {
+		if err := a.checkUpdatability(); err != nil {
+			return err
+		}
+	}
+	payload, err := json.Marshal(UpdateActivitiesRequest{Activities: activities})
+	if err != nil {
+		return fmt.Errorf("cannot marshal payload: %s", err)
+	}
+	_, err = f.Client.post(nil, "activities/", payload, nil)
+	if err != nil {
+		return fmt.Errorf("cannot update activities: %s", err)
+	}
+	return nil
+}
+
 // Unfollow is used to Unfollow a target Feed
 func (f *baseFeed) Unfollow(target Feed) error {
 	endpoint := "feed/" + f.FeedSlug + "/" + f.UserID + "/" + "following" + "/" + target.FeedID().Value() + "/"

--- a/feed_aggregated_test.go
+++ b/feed_aggregated_test.go
@@ -302,5 +302,5 @@ func TestAggregatedFeedUpdateActivities(t *testing.T) {
 		},
 	)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/feed_aggregated_test.go
+++ b/feed_aggregated_test.go
@@ -6,16 +6,18 @@ import (
 	"time"
 
 	getstream "github.com/GetStream/stream-go"
+	"github.com/stretchr/testify/assert"
 )
 
-func getAggregatedFeed(client *getstream.Client) *getstream.AggregatedFeed {
-	f, _ := client.AggregatedFeed("aggregated", RandString(8))
+func getAggregatedFeed(t *testing.T, client *getstream.Client) *getstream.AggregatedFeed {
+	f, err := client.AggregatedFeed("aggregated", RandString(8))
+	assert.Nil(t, err)
 	return f
 }
 
 func TestExampleAggregatedFeed_AddActivity(t *testing.T) {
 	client := PreTestSetup(t)
-	feed := getAggregatedFeed(client)
+	feed := getAggregatedFeed(t, client)
 
 	_, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
@@ -30,7 +32,7 @@ func TestExampleAggregatedFeed_AddActivity(t *testing.T) {
 
 func TestAggregatedFeedAddActivity(t *testing.T) {
 	client := PreTestSetup(t)
-	feed := getAggregatedFeed(client)
+	feed := getAggregatedFeed(t, client)
 
 	fid := RandString(8)
 	_, err := feed.AddActivity(&getstream.Activity{
@@ -46,8 +48,8 @@ func TestAggregatedFeedAddActivity(t *testing.T) {
 
 func TestAggregatedFeedAddActivityWithTo(t *testing.T) {
 	client := PreTestSetup(t)
-	feed := getAggregatedFeed(client)
-	toFeed := getAggregatedFeed(client)
+	feed := getAggregatedFeed(t, client)
+	toFeed := getAggregatedFeed(t, client)
 
 	_, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
@@ -63,7 +65,7 @@ func TestAggregatedFeedAddActivityWithTo(t *testing.T) {
 
 func TestAggregatedFeedRemoveActivity(t *testing.T) {
 	client := PreTestSetup(t)
-	feed := getAggregatedFeed(client)
+	feed := getAggregatedFeed(t, client)
 
 	activity, err := feed.AddActivity(&getstream.Activity{
 		Verb:   "post",
@@ -83,7 +85,7 @@ func TestAggregatedFeedRemoveActivity(t *testing.T) {
 
 func TestAggregatedFeedRemoveByForeignIDActivity(t *testing.T) {
 	client := PreTestSetup(t)
-	feed := getAggregatedFeed(client)
+	feed := getAggregatedFeed(t, client)
 
 	fid := RandString(8)
 	activity, err := feed.AddActivity(&getstream.Activity{
@@ -110,7 +112,7 @@ func TestAggregatedFeedRemoveByForeignIDActivity(t *testing.T) {
 
 func TestAggregatedFeedActivities(t *testing.T) {
 	client := PreTestSetup(t)
-	feed := getAggregatedFeed(client)
+	feed := getAggregatedFeed(t, client)
 
 	_, err := feed.AddActivity(&getstream.Activity{
 		Verb:      "post",
@@ -131,7 +133,7 @@ func TestAggregatedFeedActivities(t *testing.T) {
 
 func TestAggregatedFeedAddActivities(t *testing.T) {
 	client := PreTestSetup(t)
-	feed := getAggregatedFeed(client)
+	feed := getAggregatedFeed(t, client)
 
 	_, err := feed.AddActivities([]*getstream.Activity{
 		{
@@ -154,7 +156,7 @@ func TestAggregatedFeedAddActivities(t *testing.T) {
 
 func TestAggregatedFeedFollowUnfollow(t *testing.T) {
 	client := PreTestSetup(t)
-	feedA := getAggregatedFeed(client)
+	feedA := getAggregatedFeed(t, client)
 	feedB := getFlatFeed(t, client)
 
 	if err := feedA.FollowFeedWithCopyLimit(feedB, 20); err != nil {
@@ -188,7 +190,7 @@ func TestAggregatedFeedFollowUnfollow(t *testing.T) {
 func TestAggregatedFeedFollowKeepingHistory(t *testing.T) {
 	client := PreTestSetup(t)
 
-	feedA := getAggregatedFeed(client)
+	feedA := getAggregatedFeed(t, client)
 	feedB := getFlatFeed(t, client)
 
 	if err := feedA.FollowFeedWithCopyLimit(feedB, 20); err != nil {
@@ -282,4 +284,22 @@ func TestAggregatedActivityMetaData(t *testing.T) {
 	if string(*resultActivity.Data) != string(*activity.Data) {
 		t.Error(string(*activity.Data), string(*resultActivity.Data))
 	}
+}
+
+func TestAggregatedFeedUpdateActivities(t *testing.T) {
+	client := PreTestSetup(t)
+	feed := getAggregatedFeed(t, client)
+
+	tt, _ := time.Parse("2006-01-02T15:04:05.999999", "2017-08-31T08:29:21.151279")
+	err := feed.UpdateActivities(
+		&getstream.Activity{
+			ForeignID: "bob:123",
+			TimeStamp: &tt,
+			Actor:     "bob",
+			Verb:      "verb",
+			Object:    "object",
+		},
+	)
+
+	assert.Nil(t, err)
 }

--- a/feed_aggregated_test.go
+++ b/feed_aggregated_test.go
@@ -7,11 +7,12 @@ import (
 
 	getstream "github.com/GetStream/stream-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func getAggregatedFeed(t *testing.T, client *getstream.Client) *getstream.AggregatedFeed {
 	f, err := client.AggregatedFeed("aggregated", RandString(8))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	return f
 }
 

--- a/feed_flat_test.go
+++ b/feed_flat_test.go
@@ -447,5 +447,5 @@ func TestFlatFeedUpdateActivities(t *testing.T) {
 		},
 	)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/feed_flat_test.go
+++ b/feed_flat_test.go
@@ -8,6 +8,7 @@ import (
 
 	getstream "github.com/GetStream/stream-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -17,7 +18,7 @@ const (
 
 func getFlatFeedByName(t *testing.T, client *getstream.Client, name string) *getstream.FlatFeed {
 	feed, err := client.FlatFeed(name, RandString(8))
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	return feed
 }
 

--- a/feed_flat_test.go
+++ b/feed_flat_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	getstream "github.com/GetStream/stream-go"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -16,9 +17,7 @@ const (
 
 func getFlatFeedByName(t *testing.T, client *getstream.Client, name string) *getstream.FlatFeed {
 	feed, err := client.FlatFeed(name, RandString(8))
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.Nil(t, err)
 	return feed
 }
 
@@ -430,4 +429,22 @@ func TestRankedFlatFeedScore(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestFlatFeedUpdateActivities(t *testing.T) {
+	client := PreTestSetup(t)
+	feed := getFlatFeed(t, client)
+
+	tt, _ := time.Parse("2006-01-02T15:04:05.999999", "2017-08-31T08:29:21.151279")
+	err := feed.UpdateActivities(
+		&getstream.Activity{
+			ForeignID: "bob:123",
+			TimeStamp: &tt,
+			Actor:     "bob",
+			Verb:      "verb",
+			Object:    "object",
+		},
+	)
+
+	assert.Nil(t, err)
 }

--- a/feed_test.go
+++ b/feed_test.go
@@ -1,7 +1,12 @@
 package getstream
 
 import (
+	"os"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlatFeedBasic(t *testing.T) {
@@ -82,5 +87,86 @@ func TestNotificationFeedBasic(t *testing.T) {
 
 	if "feedGroupfeedName NWH8lcFHfHYEc2xdMs2kOhM-oII" != notificationFeed.Signature() {
 		t.Fatal()
+	}
+}
+
+func TestUpdateActivities(t *testing.T) {
+	client, err := New(&Config{
+		APIKey:    os.Getenv("STREAM_API_KEY"),
+		APISecret: os.Getenv("STREAM_API_SECRET"),
+		AppID:     os.Getenv("STREAM_APP_ID"),
+		Location:  os.Getenv("STREAM_REGION"),
+	})
+	require.Nil(t, err)
+
+	feed, err := client.FlatFeed("flat", "123")
+	require.Nil(t, err)
+
+	tt, _ := time.Parse("2006-01-02T15:04:05.999999", "2017-08-31T08:29:21.151279")
+
+	testCases := []struct {
+		tt          time.Time
+		activities  []*Activity
+		shouldError bool
+	}{
+		{
+			activities: []*Activity{
+				&Activity{
+					ForeignID: "bob:123",
+					TimeStamp: &tt,
+					Actor:     "bob",
+					Verb:      "verb",
+					Object:    "object",
+				},
+			},
+			shouldError: false,
+		},
+		{
+			activities: []*Activity{
+				&Activity{
+					TimeStamp: &tt,
+					Actor:     "bob",
+					Verb:      "verb",
+					Object:    "object",
+				},
+			},
+			shouldError: true,
+		},
+		{
+			activities: []*Activity{
+				&Activity{
+					ForeignID: "bob:123",
+					Actor:     "bob",
+					Verb:      "verb",
+					Object:    "object",
+				},
+			},
+			shouldError: true,
+		},
+		{
+			activities:  []*Activity{},
+			shouldError: true,
+		},
+		{
+			activities: []*Activity{
+				&Activity{
+					ForeignID: "alice:123",
+					TimeStamp: &tt,
+					Actor:     "alice",
+					Verb:      "verb",
+					Object:    "object",
+				},
+			},
+			shouldError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := feed.UpdateActivities(tc.activities...)
+		if tc.shouldError {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
 	}
 }

--- a/feed_test.go
+++ b/feed_test.go
@@ -1,12 +1,7 @@
 package getstream
 
 import (
-	"os"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFlatFeedBasic(t *testing.T) {
@@ -87,86 +82,5 @@ func TestNotificationFeedBasic(t *testing.T) {
 
 	if "feedGroupfeedName NWH8lcFHfHYEc2xdMs2kOhM-oII" != notificationFeed.Signature() {
 		t.Fatal()
-	}
-}
-
-func TestUpdateActivities(t *testing.T) {
-	client, err := New(&Config{
-		APIKey:    os.Getenv("STREAM_API_KEY"),
-		APISecret: os.Getenv("STREAM_API_SECRET"),
-		AppID:     os.Getenv("STREAM_APP_ID"),
-		Location:  os.Getenv("STREAM_REGION"),
-	})
-	require.Nil(t, err)
-
-	feed, err := client.FlatFeed("flat", "123")
-	require.Nil(t, err)
-
-	tt, _ := time.Parse("2006-01-02T15:04:05.999999", "2017-08-31T08:29:21.151279")
-
-	testCases := []struct {
-		tt          time.Time
-		activities  []*Activity
-		shouldError bool
-	}{
-		{
-			activities: []*Activity{
-				&Activity{
-					ForeignID: "bob:123",
-					TimeStamp: &tt,
-					Actor:     "bob",
-					Verb:      "verb",
-					Object:    "object",
-				},
-			},
-			shouldError: false,
-		},
-		{
-			activities: []*Activity{
-				&Activity{
-					TimeStamp: &tt,
-					Actor:     "bob",
-					Verb:      "verb",
-					Object:    "object",
-				},
-			},
-			shouldError: true,
-		},
-		{
-			activities: []*Activity{
-				&Activity{
-					ForeignID: "bob:123",
-					Actor:     "bob",
-					Verb:      "verb",
-					Object:    "object",
-				},
-			},
-			shouldError: true,
-		},
-		{
-			activities:  []*Activity{},
-			shouldError: true,
-		},
-		{
-			activities: []*Activity{
-				&Activity{
-					ForeignID: "alice:123",
-					TimeStamp: &tt,
-					Actor:     "alice",
-					Verb:      "verb",
-					Object:    "object",
-				},
-			},
-			shouldError: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		err := feed.UpdateActivities(tc.activities...)
-		if tc.shouldError {
-			assert.NotNil(t, err)
-		} else {
-			assert.Nil(t, err)
-		}
 	}
 }

--- a/scope_authz.go
+++ b/scope_authz.go
@@ -17,13 +17,13 @@ const (
 // Value returns a string representation
 func (a ScopeAction) Value() string {
 	switch a {
-	case 1:
+	case ScopeActionRead:
 		return "read"
-	case 2:
+	case ScopeActionWrite:
 		return "write"
-	case 4:
+	case ScopeActionDelete:
 		return "delete"
-	case 8:
+	case ScopeActionAll:
 		return "*"
 	default:
 		return ""
@@ -48,13 +48,13 @@ const (
 // Value returns a string representation
 func (a ScopeContext) Value() string {
 	switch a {
-	case 1:
+	case ScopeContextActivities:
 		return "activities"
-	case 2:
+	case ScopeContextFeed:
 		return "feed"
-	case 4:
+	case ScopeContextFollower:
 		return "follower"
-	case 8:
+	case ScopeContextAll:
 		return "*"
 	default:
 		return ""


### PR DESCRIPTION
Adds the `UpdateActivities(...*Activity)` method to feeds, so they can be properly updated (https://getstream.io/docs_rest/#activities).

Also cleans up the code a little bit and fixes a potential nil pointer exception when signing JWT requests.