### PR TITLE
fix unfollow passing keep_history as body field instead of query parameter

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -208,13 +208,10 @@ func (f *baseFeed) Unfollow(target Feed) error {
 // this means that Activities already visibile will remain
 func (f *baseFeed) UnfollowKeepingHistory(target Feed) error {
 	endpoint := "feed/" + f.FeedSlug + "/" + f.UserID + "/" + "following" + "/" + target.FeedID().Value() + "/"
-	payload, err := json.Marshal(map[string]string{
+	params := map[string]string{
 		"keep_history": "1",
-	})
-	if err != nil {
-		return err
 	}
-	return f.Client.del(f, endpoint, payload, nil)
+	return f.Client.del(f, endpoint, nil, params)
 }
 
 type feedFollows struct {

--- a/feed_aggregated_test.go
+++ b/feed_aggregated_test.go
@@ -194,14 +194,16 @@ func TestAggregatedFeedFollowKeepingHistory(t *testing.T) {
 	feedA := getAggregatedFeed(t, client)
 	feedB := getFlatFeed(t, client)
 
-	if err := feedA.FollowFeedWithCopyLimit(feedB, 20); err != nil {
-		t.Fatal(err)
-	}
+	prepareUnfollowKeepingHistory(t, feedA, feedB, func() {
+		_, err := feedA.Activities(getstream.NewFeedReadOptions())
+		require.NoError(t, err)
+	})
 
-	if err := feedA.UnfollowKeepingHistory(feedB); err != nil {
-		t.Fatal(err)
-	}
+	out, err := feedA.Activities(getstream.NewFeedReadOptions())
+	require.NoError(t, err)
 
+	require.Len(t, out.Results, 1)
+	assert.Len(t, out.Results[0].Activities, 10)
 }
 
 func TestAggregatedActivityMetaData(t *testing.T) {

--- a/feed_flat_test.go
+++ b/feed_flat_test.go
@@ -277,20 +277,18 @@ func TestFlatFeedUnFollow(t *testing.T) {
 
 func TestFlatFeedUnFollowKeepingHistory(t *testing.T) {
 	client := PreTestSetup(t)
-
 	feedA := getFlatFeed(t, client)
 	feedB := getFlatFeed(t, client)
 
-	err := feedA.FollowFeedWithCopyLimit(feedB, 20)
-	if err != nil {
-		t.Fatal(err)
-	}
+	prepareUnfollowKeepingHistory(t, feedA, feedB, func() {
+		_, err := feedA.Activities(getstream.NewFeedReadOptions())
+		require.NoError(t, err)
+	})
 
-	err = feedA.UnfollowKeepingHistory(feedB)
-	if err != nil {
-		t.Fatal(err)
-	}
+	out, err := feedA.Activities(getstream.NewFeedReadOptions())
+	require.NoError(t, err)
 
+	assert.Len(t, out.Activities, 10)
 }
 
 func TestFlatActivityMetaData(t *testing.T) {


### PR DESCRIPTION
`Unfollow` is currently passing `keep_history` as JSON body field, while it should be passed as query parameter. This PR fixes it.