### PR TITLE
add FollowMany request

### DIFF
--- a/client.go
+++ b/client.go
@@ -369,6 +369,25 @@ func (c *Client) PrepFollowNotificationFeed(targetFeed *FlatFeed, sourceFeed *No
 	}
 }
 
+// FollowMany creates multiple follow relationships at once.
+func (c *Client) FollowMany(relations []*PostFlatFeedFollowingManyInput) error {
+	return c.FollowManyCopyLimit(relations, 300)
+}
+
+// FollowMany creates multiple follow relationships at once, with the optional activity copy limit parameter passed as argument.
+func (c *Client) FollowManyCopyLimit(relations []*PostFlatFeedFollowingManyInput, activityCopyLimit int) error {
+	payload, err := json.Marshal(relations)
+	if err != nil {
+		return err
+	}
+	params := map[string]string{
+		"activity_copy_limit": fmt.Sprintf("%d", activityCopyLimit),
+	}
+	endpoint := "follow_many/"
+	_, err = c.post(nil, endpoint, payload, params)
+	return err
+}
+
 type PostActivityToManyInput struct {
 	Activity Activity `json:"activity"`
 	FeedIDs  []string `json:"feeds"`

--- a/client.go
+++ b/client.go
@@ -371,17 +371,21 @@ func (c *Client) PrepFollowNotificationFeed(targetFeed *FlatFeed, sourceFeed *No
 
 // FollowMany creates multiple follow relationships at once.
 func (c *Client) FollowMany(relations []*PostFlatFeedFollowingManyInput) error {
-	return c.FollowManyCopyLimit(relations, 300)
+	return c.FollowManyCopyLimit(relations, -1)
 }
 
 // FollowMany creates multiple follow relationships at once, with the optional activity copy limit parameter passed as argument.
+// If activityCopyLimit is -1, the argument is not sent.
 func (c *Client) FollowManyCopyLimit(relations []*PostFlatFeedFollowingManyInput, activityCopyLimit int) error {
 	payload, err := json.Marshal(relations)
 	if err != nil {
 		return err
 	}
-	params := map[string]string{
-		"activity_copy_limit": fmt.Sprintf("%d", activityCopyLimit),
+	var params map[string]string
+	if activityCopyLimit != -1 {
+		params = map[string]string{
+			"activity_copy_limit": fmt.Sprintf("%d", activityCopyLimit),
+		}
 	}
 	endpoint := "follow_many/"
 	_, err = c.post(nil, endpoint, payload, params)


### PR DESCRIPTION
This PR adds the `/follow_many` endpoint request for adding multiple follow relationships at once.